### PR TITLE
Added Surrogate-Control header

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = function nocache(options) {
   var noEtag = (options || {}).noEtag;
 
   return function nocache(req, res, next) {
+    res.setHeader('Surrogate-Control', 'no-store');
     res.setHeader('Cache-Control', 'private, no-store, no-cache, must-revalidate, proxy-revalidate');
     res.setHeader('Pragma', 'no-cache');
     res.setHeader('Expires', '0');


### PR DESCRIPTION
Shared caches like CDNs are respecting Surrogate headers ([Spec](http://www.w3.org/TR/edge-arch/)) for deciding how to cache resources. [At least for fastly.com](https://docs.fastly.com/guides/about-fastly-services/how-caching-and-cdns-work) the `Surrogate-Control` takes precedence over all other headers. In this case, though, Fastly would check the `Expires` header afterwards which is set by this library so the `Surrogate-Control` header wouldn't be necessary. Since I can't speak for all the other shared caches out there I think adding this header makes the library more robust.