### PR TITLE
Remove Pragma header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,6 @@
 
 - Dropped support for Pragma header
 
-### Changed
-
-- Shrunk package size slightly
-
-### Removed
-
-- Removed changelog from built package
-
 ## 3.0.4 - 2022-05-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.1.0 - 2023-05-31
+
+### Removed
+
+- Dropped support for Pragma header
+
+### Changed
+
+- Shrunk package size slightly
+
+### Removed
+
+- Removed changelog from built package
+
 ## 3.0.4 - 2022-05-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 3.1.0 - 2023-05-31
+## Unreleased
 
 ### Removed
 
-- Dropped support for Pragma header
+- Breaking: dropped `Pragma` header. See [#26](https://github.com/helmetjs/nocache/pull/26)
 
 ## 3.0.4 - 2022-05-21
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ const nocache = require("nocache");
 app.use(nocache());
 ```
 
-This sets four headers, disabling a lot of browser caching:
+This sets three headers, disabling a lot of browser caching:
 
 - `Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate`
-- `Pragma: no-cache`
 - `Expires: 0`
 - `Surrogate-Control: no-store`
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ module.exports = function nocache() {
       "Cache-Control",
       "no-store, no-cache, must-revalidate, proxy-revalidate"
     );
-    res.setHeader("Pragma", "no-cache");
     res.setHeader("Expires", "0");
 
     next();

--- a/test.js
+++ b/test.js
@@ -24,7 +24,6 @@ assert.deepStrictEqual(
   new Map([
     ["Surrogate-Control", "no-store"],
     ["Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate"],
-    ["Pragma", "no-cache"],
     ["Expires", "0"],
   ])
 );


### PR DESCRIPTION
**What** 
This PR removes the support for `Pragma` header from the library

**Why**
The Pragma header was initially used to provide backward compatibility with HTTP/1.0 caches. However, with the widespread adoption of HTTP/1.1 and the introduction of cache-control directives, the Pragma header has become obsolete. The cache-control directives such as "no-cache" and "no-store" are now the standard mechanisms for controlling caching behaviour. It's also not recommend to use as it as a non-standard now as per MDN docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma

So, to align with the latest web standards and best practices, we are removing the Pragma header in this PR.

Related to:https://github.com/helmetjs/nocache/issues/25 

**Open Question**
I didn't bump the version yet to minor (just introduced to CHANGELOG.md), let me know if bumping to minor makes sense here?

