### PR TITLE
ci: update actions and add Node 20, 22, 24 to test matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,13 +11,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
## What

Update CI configuration:

- Bump `actions/checkout` from v3 to v4
- Bump `actions/setup-node` from v3 to v4
- Add Node.js 20.x, 22.x, and 24.x to the CI matrix

## Why

The CI currently only tests against Node 16.x and 18.x, but Node 20 and 22 are now LTS releases (and 24 is the current active release). The GitHub Actions are also outdated at v3.

This follows the same pattern as the CI updates in the main helmet repo (e.g., helmetjs/helmet#492).