### PR TITLE
chore: update minimum Node.js version to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "email": "me@evanhahn.com"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
The `engines.node` field currently requires `>=16.0.0`, but Node.js 16 reached end-of-life in September 2023.

This updates the minimum to `>=18.0.0` to match other packages in the helmetjs ecosystem (`helmet`, `hpkp`, `feature-policy`, `clearsitedata` all require `>=18.0.0`).