### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/helmetjs/nocache",
   "repository": {
     "type": "git",
-    "url": "git://github.com/helmetjs/nocache.git"
+    "url": "git+https://github.com/helmetjs/nocache.git"
   },
   "bugs": {
     "url": "https://github.com/helmetjs/nocache/issues",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/helmetjs/nocache",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/helmetjs/nocache.git"
+    "url": "https://github.com/helmetjs/nocache.git"
   },
   "bugs": {
     "url": "https://github.com/helmetjs/nocache/issues",


### PR DESCRIPTION
## Summary
- update the package repository URL from the legacy git protocol to HTTPS
- use plain `https://github.com/helmetjs/nocache.git` to match Git's supported URL schemes

## Validation
- npm ci --no-fund
- npm test
- metadata assertion for repository/homepage/bugs URLs
- git diff --check
- git ls-remote https://github.com/helmetjs/nocache.git HEAD
